### PR TITLE
fix compile error

### DIFF
--- a/NanoLogMakeFrag
+++ b/NanoLogMakeFrag
@@ -39,7 +39,7 @@ COMWARNS := -Wall -Wformat=2 -Wextra \
 CWARNS   := $(COMWARNS) -Wmissing-prototypes -Wmissing-declarations -Wshadow \
 		-Wbad-function-cast
 CXXWARNS := $(COMWARNS) -Wno-non-template-friend -Woverloaded-virtual \
-		-Wcast-qual -Wcast-align -Wconversion -Weffc++
+		-Wcast-qual -Wcast-align -Wno-address-of-packed-member -Wconversion -Weffc++
 
 .PHONY: all
 all:


### PR DESCRIPTION
Environment: g++ 9.1.0


```
g++ -std=c++11 -O3 -DNDEBUG -g -Wall -Wformat=2 -Wextra -Wwrite-strings -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend -Woverloaded-virtual -Wcast-qual -Wcast-align -Waddress-of-packed-member -Wconversion -Weffc++ -c -o generated/GeneratedCode.o generated/GeneratedCode.cc -I ../runtime -Igenerated
../runtime/Log.cc: In member function 'bool NanoLogInternal::Log::Encoder::encodeBufferExtentStart(uint32_t, bool)':
../runtime/Log.cc:434:61: error: taking address of packed member of 'NanoLogInternal::Log::BufferExtent' may result in an unaligned pointer value [-Werror=address-of-packed-member]
  434 |     currentExtentSize = (decltype(currentExtentSize))(char*)&(tc->length);
      |   
```