### PR TITLE
Hack: Expression won't be evaluated.

### DIFF
--- a/integrationTest/expected/dictionaryFindAll.txt
+++ b/integrationTest/expected/dictionaryFindAll.txt
@@ -54,7 +54,7 @@ ieieieieieieie2
   50 | folder/../SimpleTestObject.h | 45   | In the header, I am %d
   51 | main.cc              | 435  | L=%Lf %LF %Le %LE %Lg %LG %La %LA
   52 | main.cc              | 89   | Let's try out all the types! Pointer = %p! uint8_t = %u! uint16_t = %u! uint32_t = %u! uint64_t = %lu! float = %f! double = %lf! hexadecimal = %x! Just a normal character = %c
-  53 | main.cc              | 457  | Loop test!
+  53 | main.cc              | 464  | Loop test!
   54 | main.cc              | 237  | Make sure that the inserted code is before the ++i
   55 | folder/Sample.h      | 50   | Messages in the Header File
   56 | main.cc              | 43   | More simplicity
@@ -93,3 +93,4 @@ ieieieieieieie2
   89 | main.cc              | 205  | sneaky #define LOG
   90 | main.cc              | 426  | t=%td %ti %tu %to %tx %tx
   91 | main.cc              | 417  | z=%zd %zi %zu %zo %zx %zx
+  92 | main.cc              | 451  | This value %d won't be printed.

--- a/integrationTest/main.cc
+++ b/integrationTest/main.cc
@@ -444,6 +444,13 @@ void testAllTheTypes() {
         (long double)14.0);
 }
 
+// Expression should be evaluated when severity is lower than NanoLog's.
+void expressionShouldBeEvaluated(){
+    NanoLog::setLogLevel(NOTICE);
+    int val = 0;
+    NANO_LOG(DEBUG, "This value %d won't be printed.", val++);
+    assert(val == 1);
+}
 
 int main()
 {
@@ -472,6 +479,8 @@ int main()
     st.logSomething();
 
     logLevelTest();
+
+    expressionShouldBeEvaluated();
 
     NanoLog::sync();
 

--- a/runtime/NanoLogCpp17.h
+++ b/runtime/NanoLogCpp17.h
@@ -19,6 +19,7 @@
 #include <cstring>
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <utility>
 
@@ -1005,6 +1006,9 @@ log(int &logId,
     using namespace NanoLogInternal::Log;
     assert(N == static_cast<uint32_t>(sizeof...(Ts)));
 
+    if (severity > NanoLog::getLogLevel())
+        return;
+
     if (logId == UNASSIGNED_LOGID) {
         const ParamType *array = paramTypes.data();
         StaticLogInfo info(&compress<Ts...>,
@@ -1083,9 +1087,6 @@ checkFormat(NANOLOG_PRINTF_FORMAT const char *, ...) {}
     static constexpr std::array<NanoLogInternal::ParamType, nParams> paramTypes = \
                                 NanoLogInternal::analyzeFormatString<nParams>(format); \
     static int logId = NanoLogInternal::UNASSIGNED_LOGID; \
-    \
-    if (NanoLog::severity > NanoLog::getLogLevel()) \
-        break; \
     \
     /* Triggers the GNU printf checker by passing it into a no-op function.
      * Trick: This call is surrounded by an if false so that the VA_ARGS don't


### PR DESCRIPTION
In this case:
```cpp
NanoLog::setLogLevel(NOTICE);
int val = 0;
NANO_LOG(DEBUG, "This value %d won't be printed.", val++);
```
the value of `val` is still 0 because of code at line 1087~1089 in runtime/NanoLogCpp17.h:
```cpp
if (NanoLog::severity > NanoLog::getLogLevel())
    break;
```
I moved it to function NanoLogInternal::log to make VA_ARGS be evaluated.
See an additional test case in integrationTest/main.cc.
