### PR TITLE
Fix decompression failures for compressed logs under O_DIRECT direct write mode

### DIFF
--- a/runtime/RuntimeLogger.cc
+++ b/runtime/RuntimeLogger.cc
@@ -600,7 +600,7 @@ RuntimeLogger::compressionThreadMain() {
             ssize_t bytesOver = bytesToWrite % 512;
 
             if (bytesOver != 0) {
-                memset(compressingBuffer, 0, 512 - bytesOver);
+                memset(compressingBuffer+bytesToWrite, 0, 512 - bytesOver);
                 bytesToWrite = bytesToWrite + 512 - bytesOver;
                 padBytesWritten += (512 - bytesOver);
             }


### PR DESCRIPTION
When compressing log files in the mode of direct write to O-DIECT, there may be a problem of log compression errors that cannot be correctly decompressed. The issue was fixed by modifying the padding.
<img width="1013" height="343" alt="image" src="https://github.com/user-attachments/assets/6c60ba7d-b683-4b74-8f2e-4afac349d936" />
 ### Problem
 The original code erroneously placed a 512-byte padding area at the front of the buffer. This overwrote the data structures written at the front, leading to file corruption and failure in decompression.

 ### Solution
 Move the 512-byte padding area to the end of the buffer instead of the front.

 ### Impact
 This fixes the file corruption issue and ensures correct decompression.